### PR TITLE
TASK: Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requires npm (node.js) to work out of the box, although binaries can also be ins
 
 ```composer require "moc/imageoptimizer" "~2.0"```
 
-Run `npm install --prefix Resources/Private/Library` in the package (should happen automatically during install).
+Run `npm install --prefix Resources/Private/Library` in the package.
 
 Configuration
 -------------


### PR DESCRIPTION
Remove hint on npm install being run during install, since that is not the
case (as explained in https://getcomposer.org/doc/articles/scripts.md only
scripts defined in the root manifest are executed.)
