### PR TITLE
Ability to use the binary path also globally

### DIFF
--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -120,7 +120,7 @@ class ThumbnailAspect {
 				}
 				break;
 		}
-		$binaryPath = $useGlobalBinary === TRUE ? $this->settings['globalBinaryPath'] . $library : $this->packageManager->getPackageOfObject($this)->getResourcesPath() . $binaryRootPath . $binaryPath;
+		$binaryPath = $useGlobalBinary === TRUE ? $this->settings['globalBinaryPath'] . ($this->settings['useGlobalBinaryPath'] ? $binaryPath : $library) : $this->packageManager->getPackageOfObject($this)->getResourcesPath() . $binaryRootPath . $binaryPath;
 		$cmd = escapeshellcmd($binaryPath) . ' ' . $arguments;
 		$output = [];
 		exec($cmd, $output, $result);

--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -120,7 +120,7 @@ class ThumbnailAspect {
 				}
 				break;
 		}
-		$binaryPath = $useGlobalBinary === TRUE ? $this->settings['globalBinaryPath'] . ($this->settings['useGlobalBinaryPath'] ? $binaryPath : $library) : $this->packageManager->getPackageOfObject($this)->getResourcesPath() . $binaryRootPath . $binaryPath;
+		$binaryPath = $useGlobalBinary === TRUE ? $this->settings['globalBinaryPath'] . ($this->settings['useGlobalBinaryPath'] === TRUE ? $binaryPath : $library) : $this->packageManager->getPackageOfObject($this)->getResourcesPath() . $binaryRootPath . $binaryPath;
 		$cmd = escapeshellcmd($binaryPath) . ' ' . $arguments;
 		$output = [];
 		exec($cmd, $output, $result);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,7 @@
 MOC:
   ImageOptimizer:
     useGlobalBinary: FALSE # use globally installed binaries for all formats instead
+    useGlobalBinaryPath: FALSE # if set, the binary path will also globally used
     globalBinaryPath: ''
     formats:
       jpg:


### PR DESCRIPTION
In some installation, the global path is not correct. With this
additional setting it is possible to use the binary path also on global
packages
