### PR TITLE
!!! TASK: Make libraries configurable

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -20,7 +20,7 @@ MOC:
         arguments: "${'-o' + optimizationLevel + ' -strip all -out ' + file + ' ' + file}"
         parameters:
           optimizationLevel: 2 # optimization level (0-7)
-        
+
       'image/gif':
         enabled: true
         useGlobalBinary: false # use globally installed binary for the gif library instead
@@ -29,11 +29,11 @@ MOC:
         arguments: "${'--batch -O' + optimizationLevel + ' ' + file}"
         parameters:
           optimizationLevel: 2 # optimization level (1-3)
-        
+
       'image/svg+xml':
         enabled: true
         useGlobalBinary: false # use globally installed binary for the svg library instead
-        library: 'svgo'                           
+        library: 'svgo'
         binaryPath: 'svgo/bin/svgo'
         arguments: "${(pretty ? '--pretty ' : '') + file}"
         parameters:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,19 +3,38 @@ MOC:
     useGlobalBinary: false # use globally installed binaries for all formats instead
     globalBinaryPath: ''
     formats:
-      jpg:
+      'image/jpeg':
         enabled: true
-        progressive: true # whether or not to server progressive jpgs
-        useGlobalBinary: false # use globally installed binary for jpegtran instead
-      png:
+        useGlobalBinary: false # use globally installed binary for the jpeg library instead
+        library: 'jpegtran'
+        binaryPath: 'jpegtran-bin/vendor/jpegtran'
+        arguments: "${'-copy none -optimize ' + (progressive ? '-progressive ' : '') + '-outfile ' + file + ' ' + file}"
+        parameters:
+          progressive: true # whether or not to serve progressive jpgs
+
+      'image/png':
         enabled: true
-        optimizationLevel: 2 # optimization level (0-7)
-        useGlobalBinary: false # use globally installed binary for optipng instead
-      gif:
+        useGlobalBinary: false # use globally installed binary for the png library instead
+        library: 'optipng'
+        binaryPath: 'optipng-bin/vendor/optipng'
+        arguments: "${'-o' + optimizationLevel + ' -strip all -out ' + file + ' ' + file}"
+        parameters:
+          optimizationLevel: 2 # optimization level (0-7)
+        
+      'image/gif':
         enabled: true
-        optimizationLevel: 2 # optimization level (1-3)
-        useGlobalBinary: false # use globally installed binary for gifsicle instead
-      svg:
+        useGlobalBinary: false # use globally installed binary for the gif library instead
+        library: 'gifsicle'
+        binaryPath: 'gifsicle/vendor/gifsicle'
+        arguments: "${'--batch -O' + optimizationLevel + ' ' + file}"
+        parameters:
+          optimizationLevel: 2 # optimization level (1-3)
+        
+      'image/svg+xml':
         enabled: true
-        pretty: false # keep the output readable
-        useGlobalBinary: false # use globally installed binary for svgo instead
+        useGlobalBinary: false # use globally installed binary for the svg library instead
+        library: 'svgo'                           
+        binaryPath: 'svgo/bin/svgo'
+        arguments: "${(pretty ? '--pretty ' : '') + file}"
+        parameters:
+          pretty: false # keep the output readable

--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ Add the following to your `Settings` to use `jpegoptim` instead of `jpegtran`:
         formats:
           'image/jpeg':
             enabled: true
-            progressive: true 
-            quality: 80
             library: 'jpegoptim'
             binaryPath: 'jpegoptim-bin/vendor/jpegoptim'
             arguments: "'--strip-all --max=' + quality + ' ' + (progressive ? '--all-progressive ' : '') + '-o ' + file"
-            
+            parameters:
+              progressive: true # whether or not to serve progressive jpgs
+              quality: 80 # quality level (1-100)
+
 When doing this you have to take care that you provide the necessary library yourself as it's not included 
 when doing the installation like described above.
-            
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -9,28 +9,28 @@ MOC.ImageOptimizer
 Introduction
 ------------
 
-Neos CMS / Flow framework package that optimizes generated thumbnail images (jpg, png, gif, svg) for web presentation.
+Neos CMS / Flow framework package that optimizes generated thumbnail images (jpg, png, gif, svg and more) for web presentation.
 
 Original files are never affected since copies are always created for thumbnails.
 
 Non-blocking during rendering (asynchronous) optimization.
 
-Using jpegtran, optipng, gifsicle and svgo for the optimizations.
+Using jpegtran, optipng, gifsicle and svgo or alternative customizible ones for the optimizations.
 
 Should work with Linux, FreeBSD, OSX, SunOS & Windows (only tested Linux & FreeBSD so far).
 
-Compatible with Neos 1.x-2.x+ / Flow 2.x-3.x+
+Compatible with Neos 1.x, 2.x, 3.x+ / Flow 2.x, 3.x, 4.x+
 
-##### Only supports local file system (no CDN support yet)
+##### Only supports local file system (no CDN support yet) (see #10)
 
 Installation
 ------------
 
 Requires npm (node.js) to work out of the box, although binaries can also be installed manually without it.
 
-`composer require "moc/imageoptimizer" "~2.0"`
+`composer require "moc/imageoptimizer" "~3.0"`
 
-Ensure the image manipulation libraries `jpegtran` (JPG), `optipng` (PNG), `gifsicle` (GIF) and `svgo` (SVG) are installed globally. Libraries can be skipped if desired.
+Ensure the image manipulation libraries `jpegtran` (JPG), `optipng` (PNG), `gifsicle` (GIF) and `svgo` (SVG) are installed globally. Libraries can be skipped if desired, just make sure to disable those mimetypes. 
 
 Alternatively install them using `npm`:
 ```
@@ -48,7 +48,7 @@ Using the `Settings` configuration, multiple options can be adjusted.
 
 Optimization can be disabled for specific file formats.
 
-Additionally options for optimization level (png & gif), progressive (jpg), pretty (svg) can be adjusted.
+Additionally options such as optimization level (png & gif), progressive (jpg), pretty (svg) can be adjusted depending on optimization library.
 
 Usage of global available binaries can be configured instead or for specific formats.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ Usage of global available binaries can be configured instead or for specific for
 
 Enable using the setting `MOC.ImageOptimizer.useGlobalBinary` and configure the path in `MOC.ImageOptimizer.globalBinaryPath`.
 
+Use alternative libraries for optimization
+------------------------------------------
+
+You can replace the preconfigured libraries with alternative ones.
+
+Example:
+
+Add the following to your `Settings` to use `jpegoptim` instead of `jpegtran`:
+
+    MOC:
+      ImageOptimizer:
+        formats:
+          'image/jpeg':
+            enabled: true
+            progressive: true 
+            quality: 80
+            library: 'jpegoptim'
+            binaryPath: 'jpegoptim-bin/vendor/jpegoptim'
+            arguments: "'--strip-all --max=' + quality + ' ' + (progressive ? '--all-progressive ' : '') + '-o ' + file"
+            
+When doing this you have to take care that you provide the necessary library yourself as it's not included 
+when doing the installation like described above.
+            
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Add the following to your `Settings` to use `jpegoptim` instead of `jpegtran`:
             enabled: true
             library: 'jpegoptim'
             binaryPath: 'jpegoptim-bin/vendor/jpegoptim'
-            arguments: "'--strip-all --max=' + quality + ' ' + (progressive ? '--all-progressive ' : '') + '-o ' + file"
+            arguments: "${'--strip-all --max=' + quality + ' ' + (progressive ? '--all-progressive ' : '') + '-o ' + file}"
             parameters:
               progressive: true # whether or not to serve progressive jpgs
               quality: 80 # quality level (1-100)


### PR DESCRIPTION
This change makes it possible to use alternative libraries for image manipulation which might lead to better results based on the context.

This change is breaking as the configuration is now based on the media type and not the file extension anymore.

Resolves: #15